### PR TITLE
Add Subtotals to landedCostOnly mutation

### DIFF
--- a/src/fullLandedCost/__tests__/fullLandedCost.graphql.customer.test.ts
+++ b/src/fullLandedCost/__tests__/fullLandedCost.graphql.customer.test.ts
@@ -29,7 +29,44 @@ describe('fullLandedCost data', () => {
         restriction: null,
       },
     ],
-    landedCostCalculateWorkflow: null,
+    landedCostCalculateWorkflow: [
+      {
+        amountSubtotals: {
+          duties: 0,
+          fees: 8.39,
+          items: 99.34,
+          landedCostTotal: 20.31,
+          shipping: 99.55,
+          taxes: 11.92,
+        },
+        currencyCode: 'USD',
+        deMinimis: [
+          {
+            threshold: 'BELOW',
+            type: 'DUTY',
+          },
+          {
+            threshold: 'ABOVE',
+            type: 'TAX',
+          },
+        ],
+        id: 'landed_cost_33232e5e-1c5e-44cd-8dad-b90047f5d77b',
+        method: 'DDP',
+        remittance: [],
+        rootId:
+          'zonos_internal_federated_request_8f272e76-d40b-4eb4-ad86-e284d49e8756',
+        shipmentRating: {
+          displayName: 'USPS Priority',
+          id: 'shipment_rating_aa865b31-1649-4697-8d3a-5edde01275f2',
+          maxTransitAt: null,
+          minTransitAt: null,
+          shippingProfile: {
+            customServiceLevelCode: 'USPS_PRIORITY_DOMESTIC',
+            landedCostMethod: 'DDP_PREFERRED',
+          },
+        },
+      },
+    ],
     partyCreateWorkflow: [
       {
         id: 'party_22297ddd-aed3-4873-b35c-76f1338fbd5d',

--- a/src/fullLandedCost/_fullLandedCost.graphql.customer.ts
+++ b/src/fullLandedCost/_fullLandedCost.graphql.customer.ts
@@ -45,6 +45,8 @@ export const fullLandedCost = gql`
         duties
         fees
         shipping
+        landedCostTotal
+        items
         taxes
       }
       currencyCode

--- a/src/landedCostOnly/__tests__/landedCostOnly.graphql.customer.test.ts
+++ b/src/landedCostOnly/__tests__/landedCostOnly.graphql.customer.test.ts
@@ -29,7 +29,44 @@ describe('landedCostOnly data', () => {
         restriction: null,
       },
     ],
-    landedCostCalculateWorkflow: null,
+    landedCostCalculateWorkflow: [
+      {
+        amountSubtotals: {
+          duties: 0,
+          fees: 8.39,
+          items: 99.34,
+          landedCostTotal: 20.31,
+          shipping: 99.55,
+          taxes: 11.92,
+        },
+        currencyCode: 'USD',
+        deMinimis: [
+          {
+            threshold: 'BELOW',
+            type: 'DUTY',
+          },
+          {
+            threshold: 'ABOVE',
+            type: 'TAX',
+          },
+        ],
+        id: 'landed_cost_33232e5e-1c5e-44cd-8dad-b90047f5d77b',
+        method: 'DDP',
+        remittance: [],
+        rootId:
+          'zonos_internal_federated_request_8f272e76-d40b-4eb4-ad86-e284d49e8756',
+        shipmentRating: {
+          displayName: 'USPS Priority',
+          id: 'shipment_rating_aa865b31-1649-4697-8d3a-5edde01275f2',
+          maxTransitAt: null,
+          minTransitAt: null,
+          shippingProfile: {
+            customServiceLevelCode: 'USPS_PRIORITY_DOMESTIC',
+            landedCostMethod: 'DDP_PREFERRED',
+          },
+        },
+      },
+    ],
     partyCreateWorkflow: [
       {
         id: 'party_22297ddd-aed3-4873-b35c-76f1338fbd5d',

--- a/src/landedCostOnly/_landedCostOnly.graphql.customer.ts
+++ b/src/landedCostOnly/_landedCostOnly.graphql.customer.ts
@@ -46,6 +46,8 @@ export const landedCostOnly = gql`
         duties
         fees
         shipping
+        landedCostTotal
+        items
         taxes
       }
       currencyCode

--- a/src/types/generated/graphql.customer.types.ts
+++ b/src/types/generated/graphql.customer.types.ts
@@ -1117,6 +1117,8 @@ export type ZonosCatalogItem = {
   provinceOfOrigin: Maybe<Scalars['String']>;
   /** A list of restricted country code */
   restrictedCountries: Maybe<Array<Maybe<ZonosCountryCode>>>;
+  /** The suggested retail amount */
+  retailAmount: Maybe<Scalars['Decimal']>;
   /** SKU of this `CatalogItem`. */
   sku: Maybe<Scalars['String']>;
   /** Source of `CatalogItem`. */
@@ -1320,6 +1322,8 @@ export type ZonosCatalogItemInclusivePrice = {
   organizationId: Scalars['String'];
   /** the preferred amount */
   preferred: ZonosInclusivePriceBreakdown;
+  /** The suggested retail amount */
+  retailAmount: Maybe<Scalars['Decimal']>;
   /** Ship to country */
   shipToCountry: ZonosCountryCode;
   /** Whether this price has been sync to a merchant catalog */
@@ -1385,6 +1389,8 @@ export type ZonosCatalogItemInput = {
   provinceOfOrigin?: InputMaybe<Scalars['String']>;
   /** A list of restricted country code */
   restrictedCountries?: InputMaybe<Array<InputMaybe<ZonosCountryCode>>>;
+  /** The suggested retail amount */
+  retailAmount?: InputMaybe<Scalars['Decimal']>;
   /** SKU of this `CatalogItem`. */
   sku?: InputMaybe<Scalars['String']>;
 };
@@ -10862,7 +10868,7 @@ export type ZonosFullLandedCostMutation = (
     & Pick<ZonosLandedCost, 'currencyCode' | 'id' | 'method' | 'rootId'>
     & { amountSubtotals: Maybe<(
       { __typename?: 'LandedCostAmountSubtotals' }
-      & Pick<ZonosLandedCostAmountSubtotals, 'duties' | 'fees' | 'shipping' | 'taxes'>
+      & Pick<ZonosLandedCostAmountSubtotals, 'duties' | 'fees' | 'shipping' | 'landedCostTotal' | 'items' | 'taxes'>
     )>, deMinimis: Array<(
       { __typename?: 'DeMinimis' }
       & Pick<ZonosDeMinimis, 'threshold' | 'type'>
@@ -10915,7 +10921,7 @@ export type ZonosLandedCostOnlyMutation = (
     & Pick<ZonosLandedCost, 'currencyCode' | 'id' | 'method' | 'rootId'>
     & { amountSubtotals: Maybe<(
       { __typename?: 'LandedCostAmountSubtotals' }
-      & Pick<ZonosLandedCostAmountSubtotals, 'duties' | 'fees' | 'shipping' | 'taxes'>
+      & Pick<ZonosLandedCostAmountSubtotals, 'duties' | 'fees' | 'shipping' | 'landedCostTotal' | 'items' | 'taxes'>
     )>, deMinimis: Array<(
       { __typename?: 'DeMinimis' }
       & Pick<ZonosDeMinimis, 'threshold' | 'type'>
@@ -11051,6 +11057,8 @@ export const FullLandedCostDocument = `
       duties
       fees
       shipping
+      landedCostTotal
+      items
       taxes
     }
     currencyCode
@@ -11114,6 +11122,8 @@ export const LandedCostOnlyDocument = `
       duties
       fees
       shipping
+      landedCostTotal
+      items
       taxes
     }
     currencyCode


### PR DESCRIPTION
## Issue
<!-- Example:
Error when importing the sdk
-->

## Description
<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
This PR adds subtotals to landedCostOnly mutation
