### PR TITLE
Update publish workflow permissions and remove NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -18,10 +22,10 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org
           cache: pnpm
+      # Ensure npm 11.5.1 or later for trusted publishing
+      - run: npm install -g npm@latest
       - run: pnpm install
       - run: pnpm build
         env:
           CUSTOMER_GRAPH_URL: ${{ secrets.CUSTOMER_GRAPH_URL }}
       - run: cd dist && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION


## Description
<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->
This PR updates the publish workflow to include necessary permissions for OIDC and removes the use of NODE_AUTH_TOKEN for npm publishing.

