### PR TITLE
DEV-1021: Add Datadog service catalog definition

### DIFF
--- a/.github/service.datadog.yaml
+++ b/.github/service.datadog.yaml
@@ -1,0 +1,33 @@
+apiVersion: v3
+kind: service
+metadata:
+  name: fe-10-typescript-sdk
+  owner: team-16
+  additionalOwners:
+    - name: devops
+      type: infra
+  tags:
+    - language:typescript
+    - cloud_provider:aws
+  contacts:
+    - name: team-16-hello
+      type: slack
+      contact: https://zonos.slack.com/archives/C0APYQ68LH4
+  links:
+    - name: Source Code
+      type: repo
+      url: https://github.com/Zonos/fe-10-typescript-sdk
+      provider: github
+spec:
+  lifecycle: production
+  tier: "bronze"
+  type: web
+  languages:
+    - typescript
+datadog:
+  codeLocations:
+    - repositoryURL: https://github.com/Zonos/fe-10-typescript-sdk
+extensions:
+  datadoghq.com/ci-pipelines:
+    - name: fe-10-typescript-sdk
+      provider: github


### PR DESCRIPTION
## Summary

- Adds `.github/service.datadog.yaml` (v3 schema) for the Datadog Software Catalog
- Sets service owner to `team-16` with `devops` as infra co-owner
- Includes Slack contact, repo link, language tags, tier, and lifecycle metadata

## Test plan

- [ ] Verify yaml renders correctly in Datadog Software Catalog after merge
- [ ] Confirm team ownership shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds metadata-only YAML for Datadog catalog/CI visibility with no runtime or application logic changes.
> 
> **Overview**
> Introduces `.github/service.datadog.yaml` (Datadog Software Catalog v3) to register `fe-10-typescript-sdk` with ownership, contacts, tags, and repo link metadata.
> 
> Also declares catalog attributes (lifecycle/tier/type/language), associates the repo as a code location, and links the GitHub CI pipeline via the `datadoghq.com/ci-pipelines` extension.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32585c242f3dd5f446843883380679baabcdd611. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->