### PR TITLE
chore: add CI security gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -68,9 +71,11 @@ jobs:
     name: Security gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10.x
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,15 @@ jobs:
       - run: pnpm test:prod
         env:
           CUSTOMER_GRAPH_URL: ${{ secrets.CUSTOMER_GRAPH_URL }}
+
+  SecurityGate:
+    name: Security gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm audit --audit-level high

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@zonos/typescript-sdk",
   "version": "0.2.0",
   "description": "Streamline international ecommerce with the Zonos TypeScript SDK",
-  "repository": "git@github.com:Zonos/typescript-sdk.git",
+  "repository": "git@github.com:Zonos/fe-10-typescript-sdk.git",
   "license": "MIT",
   "private": false,
   "peerDependencies": {


### PR DESCRIPTION
## Summary

- Adds a `SecurityGate` CI job that runs `pnpm audit --audit-level high` on every push
- Blocks builds when high-severity vulnerabilities are detected in dependencies
- Matches the pattern already in place in fe-6-account-web

## Test plan

- [ ] Verify the `Security gate` job appears in the CI checks
- [ ] Confirm the job passes on a clean dependency tree

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and metadata-only changes; no runtime or auth logic in the SDK.
> 
> **Overview**
> Adds a **Security gate** CI job that runs `pnpm audit --audit-level high` on every push so high-severity dependency issues fail the pipeline, aligned with the fe-6-account-web pattern.
> 
> The workflow also sets **`permissions: contents: read`** on the workflow (least-privilege for the default token). **`package.json`** updates the `repository` URL to `Zonos/fe-10-typescript-sdk.git`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a71bc16dd8ca7f3c449a17b5c5aa92e6069b2b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->